### PR TITLE
Feat: 에러 핸들링에 에러 로그 추가

### DIFF
--- a/src/main/java/com/std/tothebook/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/std/tothebook/exception/GlobalExceptionHandler.java
@@ -1,19 +1,24 @@
 package com.std.tothebook.exception;
 
 import com.std.tothebook.exception.dto.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(ExpectedException.class)
     public ResponseEntity<ErrorResponse> handleCustomException(ExpectedException e) {
-        // TODO log
-        System.out.println(e.toString());
+        this.log(e);
         return StringUtils.hasText(e.getMessage()) ? ErrorResponse.errorWithMessage(e) : ErrorResponse.error(e);
+    }
+
+    private void log(ExpectedException e) {
+        log.error("{} : {}", e.toString(), e.getErrorCode() == null ? e.getMessage() : e.getErrorCode().getMessage());
     }
 }


### PR DESCRIPTION
### 글로벌 에러를 로그에 찍는 작업입니다.

1. 에러 위치를 표현하기 위해 ```toString```으로 하였습니다.
2. 에러 코드 존재 시 errorCode의 message를 적고, 존재하지 않으면 그냥 message를 적습니다.
(message가 없으면 null이 적힐 것으로 예상합니다.)