### PR TITLE
fix: 어플리케이션 실행 시 Security exclude 설정 제거

### DIFF
--- a/src/main/java/com/std/tothebook/TothebookApplication.java
+++ b/src/main/java/com/std/tothebook/TothebookApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class TothebookApplication {
 
 	public static void main(String[] args) {


### PR DESCRIPTION
### Application 설정 제거

기존 프로젝트 생성 시 Security dependency가 적용되었으나 설정된 게 없어서 로그인 화면이 뜨던 것을 임시로 막던 코드를 제거했습니다.