### PR TITLE
feat: Security 익명 사용자 처리

### DIFF
--- a/src/main/java/com/std/tothebook/config/JwtTokenProvider.java
+++ b/src/main/java/com/std/tothebook/config/JwtTokenProvider.java
@@ -1,12 +1,14 @@
 package com.std.tothebook.config;
 
 import com.std.tothebook.api.enums.AuthorizationType;
+import com.std.tothebook.exception.JwtAuthenticationException;
 import com.std.tothebook.security.JsonWebToken;
 import com.std.tothebook.security.SecurityUser;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -100,7 +102,11 @@ public class JwtTokenProvider {
 
     // 인증된 회원 정보 조회
     public SecurityUser getUser() {
-        return (SecurityUser) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof AnonymousAuthenticationToken) {
+            throw JwtAuthenticationException.create("인증 되지 않은 사용자입니다.");
+        }
+        return (SecurityUser) authentication.getPrincipal();
     }
 
     // 인증된 회원 id 조회

--- a/src/main/java/com/std/tothebook/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/std/tothebook/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.std.tothebook.exception;
 
 import com.std.tothebook.exception.dto.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.util.StringUtils;
@@ -16,6 +17,18 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleCustomException(ExpectedException e) {
         this.log(e);
         return StringUtils.hasText(e.getMessage()) ? ErrorResponse.errorWithMessage(e) : ErrorResponse.error(e);
+    }
+
+    @ExceptionHandler(JwtAuthenticationException.class)
+    public ResponseEntity<ErrorResponse> handleAuthenticationException(JwtAuthenticationException e) {
+        log.error("{} : {}", e.toString(), e.getMessage());
+
+        // ExpectedException을 상속 받지 않기 때문에 아래와 같이 구현
+        final var response = new ErrorResponse(HttpStatus.UNAUTHORIZED, "", e.getMessage());
+
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(response);
     }
 
     private void log(ExpectedException e) {

--- a/src/main/java/com/std/tothebook/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/std/tothebook/exception/JwtAuthenticationException.java
@@ -1,0 +1,15 @@
+package com.std.tothebook.exception;
+
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+    public JwtAuthenticationException(String message) {
+        super(message);
+    }
+
+    public static JwtAuthenticationException create(String message) {
+        return new JwtAuthenticationException(message);
+    }
+}

--- a/src/main/java/com/std/tothebook/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/std/tothebook/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.std.tothebook.security;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        // 추후 로그인 페이지로 이동 예정
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/std/tothebook/security/SecurityConfig.java
+++ b/src/main/java/com/std/tothebook/security/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.AccessDeniedHandlerImpl;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
@@ -26,8 +27,14 @@ public class SecurityConfig {
                 .and()
                 .formLogin().disable()
                 .httpBasic().disable()
-                .authorizeRequests()
-                .antMatchers("/**").permitAll()
+                .authorizeHttpRequests(authorizeRequest ->
+                        authorizeRequest
+                                .antMatchers("/**")
+                                .permitAll()
+                )
+                .exceptionHandling()
+                .authenticationEntryPoint(new JwtAuthenticationEntryPoint()) // 인증
+                .accessDeniedHandler(new AccessDeniedHandlerImpl()) // 인가 (현재 인가 없음)
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 


### PR DESCRIPTION
### Security 로그인 이용 시 익명 사용자 처리 추가

JwtTokenProvider에서는 회원의 정보를 조회해오는 기능이 있습니다.
이때 로그인 하지 않은 사용자는 null 처리가 되는 것이 아니라 '익명 사용자'라는 취급을 받게 됩니다.
이때 익명 사용자는 회원 정보를 조회해올 수 없으니 이때 401 에러를 리턴하도록 내용 추가했습니다.

- JwtTokenProvider 내 회원 조회 시 익명사용자 401 에러 처리
- SecurityConfig 내 exception handler 추가