### PR TITLE
Feat: Refresh Token 기능 추가

### DIFF
--- a/src/main/java/com/std/tothebook/api/controller/api/TokenController.java
+++ b/src/main/java/com/std/tothebook/api/controller/api/TokenController.java
@@ -1,16 +1,15 @@
 package com.std.tothebook.api.controller.api;
 
+import com.std.tothebook.api.service.JwtTokenService;
 import com.std.tothebook.api.service.TokenService;
 import com.std.tothebook.config.JwtTokenProvider;
 import com.std.tothebook.security.JsonWebToken;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * 매번 로그인 하기 귀찮을 때 임시로 발급하기 위한 컨트롤러
@@ -22,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class TokenController {
 
     private final TokenService tokenService;
+    private final JwtTokenService jwtTokenService;
 
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -41,6 +41,14 @@ public class TokenController {
     @GetMapping("/by-id/{id}")
     public ResponseEntity<JsonWebToken> getTokenById(@PathVariable long id) {
         return ResponseEntity.ok(tokenService.getTokenById(id));
+    }
+
+    @Operation(summary = "refresh 토큰으로 access 토큰 발급", description = "이때는 access token 발급만 진행된다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<String> getRefreshToken(@RequestHeader HttpHeaders httpHeaders) {
+        final var response = tokenService.refresh(httpHeaders);
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/std/tothebook/api/entity/RefreshToken.java
+++ b/src/main/java/com/std/tothebook/api/entity/RefreshToken.java
@@ -1,0 +1,38 @@
+package com.std.tothebook.api.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "refresh_token")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    // 회원 번호
+    @Column(name = "user_id", nullable = false)
+    private long userId;
+
+    // 토큰
+    @Column(nullable = false)
+    private String token;
+
+    // 만료 일시
+    @Column(name = "expired_at", nullable = false)
+    private LocalDateTime expiredAt;
+
+    protected RefreshToken() {}
+
+    @Builder
+    public RefreshToken(long userId, String token, LocalDateTime expiredAt) {
+        this.userId = userId;
+        this.token = token;
+        this.expiredAt = expiredAt;
+    }
+}

--- a/src/main/java/com/std/tothebook/api/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/std/tothebook/api/repository/RefreshTokenRepository.java
@@ -1,0 +1,15 @@
+package com.std.tothebook.api.repository;
+
+import com.std.tothebook.api.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    void deleteByUserId(long userId);
+
+    Optional<RefreshToken> findFirstByToken(String token);
+}

--- a/src/main/java/com/std/tothebook/api/service/JwtTokenService.java
+++ b/src/main/java/com/std/tothebook/api/service/JwtTokenService.java
@@ -1,0 +1,34 @@
+package com.std.tothebook.api.service;
+
+import com.std.tothebook.api.entity.RefreshToken;
+import com.std.tothebook.api.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class JwtTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    /**
+     * refresh 토큰 저장
+     */
+    @Transactional
+    public void handleRefreshToken(long userId, String token, Date expiredDate) {
+        refreshTokenRepository.deleteByUserId(userId);
+
+        refreshTokenRepository.save(
+                RefreshToken.builder()
+                        .userId(userId)
+                        .token(token)
+                        .expiredAt(LocalDateTime.ofInstant(expiredDate.toInstant(), ZoneId.systemDefault()))
+                        .build()
+        );
+    }
+}

--- a/src/main/java/com/std/tothebook/api/service/TokenService.java
+++ b/src/main/java/com/std/tothebook/api/service/TokenService.java
@@ -1,25 +1,28 @@
 package com.std.tothebook.api.service;
 
+import com.std.tothebook.api.entity.RefreshToken;
 import com.std.tothebook.api.entity.User;
+import com.std.tothebook.api.repository.RefreshTokenRepository;
 import com.std.tothebook.api.repository.UserRepository;
 import com.std.tothebook.config.JwtTokenProvider;
 import com.std.tothebook.exception.ExpectedException;
+import com.std.tothebook.exception.JwtAuthenticationException;
 import com.std.tothebook.exception.enums.ErrorCode;
 import com.std.tothebook.security.JsonWebToken;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class TokenService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     private final JwtTokenProvider jwtTokenProvider;
-
-    // 토큰 저장
-
-    // 토큰 존재 여부 체크
 
     // 이메일로 토큰 발급
     public JsonWebToken getTokenByEmail(String email) {
@@ -35,5 +38,22 @@ public class TokenService {
                 .orElseThrow(() -> new ExpectedException(ErrorCode.USER_NOT_FOUND));
 
         return jwtTokenProvider.createToken(user.getId());
+    }
+
+
+    /**
+     * access token 재발급
+     */
+    public String refresh(HttpHeaders httpHeaders) {
+        List<String> refreshTokenList = httpHeaders.get("Refresh-token");
+        if (refreshTokenList == null || refreshTokenList.isEmpty()) {
+            throw new JwtAuthenticationException("토큰이 존재하지 않습니다.");
+        }
+        String token = refreshTokenList.get(0);
+
+        RefreshToken refreshToken = refreshTokenRepository.findFirstByToken(token)
+                .orElseThrow(() -> new JwtAuthenticationException("토큰이 알맞지 않습니다."));
+
+        return jwtTokenProvider.createAccessToken(refreshToken.getUserId());
     }
 }

--- a/src/main/java/com/std/tothebook/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/std/tothebook/security/filter/JwtAuthenticationFilter.java
@@ -2,7 +2,9 @@ package com.std.tothebook.security.filter;
 
 import com.std.tothebook.api.enums.AuthorizationType;
 import com.std.tothebook.config.JwtTokenProvider;
+import com.std.tothebook.exception.JwtAuthenticationException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -14,6 +16,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
@@ -24,17 +27,33 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         String token = resolveToken((HttpServletRequest) request);
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String requestURI = httpServletRequest.getRequestURI();
+
+        // refresh token
+        if (requestURI.equals("/token/refresh")) {
+            String refreshToken = httpServletRequest.getHeader("Refresh-token");
+
+            if (Objects.isNull(token) || Objects.isNull(refreshToken)) {
+                // TODO: filter exception handling
+                throw new JwtAuthenticationException("토큰이 존재하지 않습니다.");
+            }
+            if (!jwtTokenProvider.validateToken(refreshToken)) {
+                throw new JwtAuthenticationException("토큰 오류가 발생했습니다.");
+            }
+        } else if (!Objects.isNull(token) && jwtTokenProvider.validateToken(token)) {
+            // access token
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
+
         chain.doFilter(request, response);
     }
 
     // Request 헤더에서 token 값 가져오기
     // Bearer 체크
     public String resolveToken(HttpServletRequest request) {
-        String token = request.getHeader("Authorization");
+        String token = request.getHeader(HttpHeaders.AUTHORIZATION);
 
         if (StringUtils.hasText(token) && token.startsWith(AuthorizationType.BEARER.getCode())) {
             return token.substring(7);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -62,5 +62,5 @@ springdoc:
 # jwt
 jwt:
   key: wuc7+P1EsZRQTgFha2y/TKJORNFmacS24V2uSvCCG2IEAvbe3dRg1FjA02PHyqV5PYaiuK+kh4WvOowaDoRKR3KweWtA8O/C
-  expired-time: 60000 # 1분
+  expired-time: 120000 # 2분
   refresh-expired-time: 600000 # 10분


### PR DESCRIPTION
### Refresh Token 기능 추가

- access token 유효 기간 2분으로 수정

access token이 만료되었을 때 refresh token으로 access token을 재발급 받는 기능을 추가하였습니다.

### 사용 방법
1. 최초 access token 발급 시 refresh token을 같이 발급합니다. (이때 refresh token은 서버에 저장됩니다.)
2. access token의 만료 시간이 지나면 401 에러가 발생합니다.
3. 이때 헤더에 'refresh-token'이라는 이름으로 1번에서 발급했던 refresh token을 담아, /token/refresh 을 실행합니다.
4. /token/refresh 에서 access token을 발급합니다.
5. 사용자 단에서 access token을 이용해 로그인 된 상태를 유지합니다.