### PR TITLE
Feat: Swagger Refresh Token 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity5'
 	implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
-	implementation 'org.springdoc:springdoc-openapi-ui:1.6.14'
+	implementation 'org.springdoc:springdoc-openapi-ui:1.6.4'
 	implementation 'com.querydsl:querydsl-jpa'
 	implementation 'com.querydsl:querydsl-apt'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'

--- a/src/main/java/com/std/tothebook/api/enums/AuthorizationType.java
+++ b/src/main/java/com/std/tothebook/api/enums/AuthorizationType.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthorizationType {
-    BEARER("Bearer");
+    BEARER("Bearer"),
+    REFRESH_TOKEN("Refresh-token");
 
     private final String code;
 }

--- a/src/main/java/com/std/tothebook/api/service/TokenService.java
+++ b/src/main/java/com/std/tothebook/api/service/TokenService.java
@@ -2,6 +2,7 @@ package com.std.tothebook.api.service;
 
 import com.std.tothebook.api.entity.RefreshToken;
 import com.std.tothebook.api.entity.User;
+import com.std.tothebook.api.enums.AuthorizationType;
 import com.std.tothebook.api.repository.RefreshTokenRepository;
 import com.std.tothebook.api.repository.UserRepository;
 import com.std.tothebook.config.JwtTokenProvider;
@@ -45,7 +46,7 @@ public class TokenService {
      * access token 재발급
      */
     public String refresh(HttpHeaders httpHeaders) {
-        List<String> refreshTokenList = httpHeaders.get("Refresh-token");
+        List<String> refreshTokenList = httpHeaders.get(AuthorizationType.REFRESH_TOKEN.getCode());
         if (refreshTokenList == null || refreshTokenList.isEmpty()) {
             throw new JwtAuthenticationException("토큰이 존재하지 않습니다.");
         }

--- a/src/main/java/com/std/tothebook/config/SwaggerConfig.java
+++ b/src/main/java/com/std/tothebook/config/SwaggerConfig.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 
 @Configuration
 public class SwaggerConfig {
@@ -24,21 +25,26 @@ public class SwaggerConfig {
                         .url("https://github.com/kimzoo2/tothebook")
                 );
 
-        String key = "Bearer 인증";
+        String key = "Access Token (Bearer)";
+        String refreshKey = "Refresh Token";
 
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList(key);
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(key).addList(refreshKey);
+
+        SecurityScheme accessTokenSecurityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme(AuthorizationType.BEARER.getCode())
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        SecurityScheme refreshTokenSecurityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.HEADER)
+                .name(AuthorizationType.REFRESH_TOKEN.getCode());
 
         Components components = new Components()
-                .addSecuritySchemes(
-                        key,
-                        new SecurityScheme()
-                                .name(key)
-                                .type(SecurityScheme.Type.HTTP)
-                                .scheme(AuthorizationType.BEARER.getCode())
-                                .bearerFormat("JWT")
-                                .in(SecurityScheme.In.HEADER)
-                                .name("Authorization")
-                );
+                .addSecuritySchemes(key, accessTokenSecurityScheme)
+                .addSecuritySchemes(refreshKey, refreshTokenSecurityScheme);
 
         return new OpenAPI()
                 .info(info)

--- a/src/main/java/com/std/tothebook/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/std/tothebook/security/filter/JwtAuthenticationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
         // refresh token
         if (requestURI.equals("/token/refresh")) {
-            String refreshToken = httpServletRequest.getHeader("Refresh-token");
+            String refreshToken = httpServletRequest.getHeader(AuthorizationType.REFRESH_TOKEN.getCode());
 
             if (Objects.isNull(token) || Objects.isNull(refreshToken)) {
                 // TODO: filter exception handling


### PR DESCRIPTION
### refresh token 을 swagger에서 다루기 위한 기능 추가

현재 swagger에는 access token만 인증할 수 있도록 되어있어서 refresh token도 함께 헤더에 설정할 수 있도록 설정 수정하였습니다.