### PR TITLE
Refactor : 엔티티 연관관계 변경, 필드 변수 타입 변경 및 Repository 인터페이스 추가

### DIFF
--- a/src/main/java/com/std/tothebook/api/entity/Book.java
+++ b/src/main/java/com/std/tothebook/api/entity/Book.java
@@ -7,8 +7,6 @@ import javax.persistence.Entity;
 import javax.persistence.*;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Getter
@@ -21,8 +19,8 @@ public class Book {
     private long id;
 
     // 카테고리 번호
-    @OneToOne
-    @JoinColumn(name = "id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
     private Category category;
 
     // 제목
@@ -47,7 +45,7 @@ public class Book {
 
     // 페이지
     @Column(name = "page")
-    private int page;
+    private Integer page;
 
     // 설명
     @Column(name = "contents", columnDefinition = "TEXT")
@@ -72,9 +70,6 @@ public class Book {
     // 삭제여부
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted;
-
-    @OneToMany(mappedBy = "book")
-    private List<MyBook> myBooks = new ArrayList<>();
 
     protected Book() {}
 

--- a/src/main/java/com/std/tothebook/api/entity/MyBook.java
+++ b/src/main/java/com/std/tothebook/api/entity/MyBook.java
@@ -1,6 +1,7 @@
 package com.std.tothebook.api.entity;
 
 import com.std.tothebook.api.enums.MyBookStatus;
+import lombok.Builder;
 import lombok.Getter;
 import javax.persistence.Entity;
 import javax.persistence.*;
@@ -37,11 +38,11 @@ public class MyBook {
 
     // 현재 페이지
     @Column(name = "page")
-    private int page;
+    private Integer page;
 
     // 별점
     @Column(name = "rating")
-    private int rating;
+    private Integer rating;
 
     // 독서 상태
     @Column(name = "status", nullable = false)
@@ -62,6 +63,7 @@ public class MyBook {
 
     protected MyBook() {}
 
+    @Builder
     public MyBook(User user, Book book, MyBookStatus myBookStatus) {
         this.user = user;
         this.book = book;

--- a/src/main/java/com/std/tothebook/api/repository/MyBookRepository.java
+++ b/src/main/java/com/std/tothebook/api/repository/MyBookRepository.java
@@ -1,0 +1,9 @@
+package com.std.tothebook.api.repository;
+
+import com.std.tothebook.api.entity.MyBook;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MyBookRepository extends JpaRepository<MyBook, Long>, MyBookCustomRepository {
+}

--- a/src/main/java/com/std/tothebook/api/service/MyBookService.java
+++ b/src/main/java/com/std/tothebook/api/service/MyBookService.java
@@ -2,7 +2,7 @@ package com.std.tothebook.api.service;
 
 import com.std.tothebook.api.domain.dto.FindMyBookResponse;
 import com.std.tothebook.api.domain.dto.FindMyBooksResponse;
-import com.std.tothebook.api.repository.MyBookCustomRepository;
+import com.std.tothebook.api.repository.MyBookRepository;
 import com.std.tothebook.exception.ExpectedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -17,17 +17,17 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MyBookService {
 
-    private final MyBookCustomRepository myBookCustomRepository;
+    private final MyBookRepository myBookRepository;
 
     public List<FindMyBooksResponse> getMybooks(long userId){
-        final var myBooks = myBookCustomRepository.findMyBookByUserId(userId);
+        final var myBooks = myBookRepository.findMyBookByUserId(userId);
 
         return myBooks;
     }
 
     public FindMyBookResponse getMyBook(long id){
 
-        Optional<FindMyBookResponse> optionalMyBook = myBookCustomRepository.findMyBookById(id);
+        Optional<FindMyBookResponse> optionalMyBook = myBookRepository.findMyBookById(id);
 
         // 요청한 user와 게시글 등록한 user 검증 필요
 


### PR DESCRIPTION
## 엔티티 연관관계, 타입 변경 및 MyBookRepository 추가

### 설명
1. Book에서 MyBook을 일반적으로 참조하는 경우가 없기 때문에 양방향 연관관계를 단방향으로 변경하였습니다.
2. Book 엔티티에 Category와 OneToOne 연관관계를 변경하였습니다. 🤣
3. 엔티티의 null 값 허용된 변수들을 Integer 타입으로 변경하였습니다.
4. JpaRepository를 상속받은 MyBookRepository를 추가하였습니다. 추후 MyBook 등록과 변경 시 사용할 예정입니다.