### PR TITLE
Feat : 독서 기록(내 서재) 등록 기능 추가

### DIFF
--- a/src/main/java/com/std/tothebook/api/controller/api/MyBookController.java
+++ b/src/main/java/com/std/tothebook/api/controller/api/MyBookController.java
@@ -1,6 +1,8 @@
 package com.std.tothebook.api.controller.api;
 
+import com.std.tothebook.api.domain.dto.AddMyBookRequest;
 import com.std.tothebook.api.domain.dto.FindMyBookResponse;
+import com.std.tothebook.api.entity.MyBook;
 import com.std.tothebook.api.service.MyBookService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -8,9 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "독서기록")
 @RequestMapping("/api/myBook")
@@ -42,5 +42,17 @@ public class MyBookController {
         // 화면 수정 중이라 ResponseEntity 형태로 return
         // 화면 수정 완료 후, viewPath로 변경할 예정
         return ResponseEntity.ok(myBook);
+    }
+
+    @Operation(summary = "독서기록 등록")
+    @PostMapping("")
+    public ResponseEntity<Void> addMyBook(@RequestBody AddMyBookRequest request){
+        final var myBook = myBookService.addMyBook(request);
+
+        // 상세 화면으로 redirect하도록 변경 예정
+//        redirectAttributes.addAttribute("id", myBook.getId());
+//        return "redirect:/basic/items/{itemId}";
+
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/std/tothebook/api/domain/dto/AddMyBookRequest.java
+++ b/src/main/java/com/std/tothebook/api/domain/dto/AddMyBookRequest.java
@@ -1,0 +1,53 @@
+package com.std.tothebook.api.domain.dto;
+
+import com.std.tothebook.api.entity.MyBook;
+import com.std.tothebook.api.enums.MyBookStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "내 서재 Request")
+public class AddMyBookRequest {
+
+    @Schema(description = "고객 id")
+    private long userId;
+
+    @Schema(description = "책 id")
+    private long bookId;
+
+    // 시작일
+    @Schema(description = "시작일")
+    private LocalDate startDate;
+
+    // 종료일
+    @Schema(description = "종료일")
+    private LocalDate endDate;
+
+    // 현재 페이지
+    @Schema(description = "현재 페이지")
+    private Integer page;
+
+    // 별점
+    @Schema(description = "별점")
+    private Integer rating;
+
+    // 독서 상태
+    @Schema(description = "독서상태")
+    private MyBookStatus myBookStatus;
+
+    // 등록일
+    @Schema(description = "등록일")
+    private LocalDateTime createdDate;
+
+    // 수정일
+    @Schema(description = "수정일")
+    private LocalDateTime updateDate;
+
+}

--- a/src/main/java/com/std/tothebook/api/entity/Book.java
+++ b/src/main/java/com/std/tothebook/api/entity/Book.java
@@ -1,5 +1,6 @@
 package com.std.tothebook.api.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -19,6 +20,7 @@ public class Book {
     private long id;
 
     // 카테고리 번호
+    @JsonIgnore
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id", nullable = false)
     private Category category;

--- a/src/main/java/com/std/tothebook/api/entity/MyBook.java
+++ b/src/main/java/com/std/tothebook/api/entity/MyBook.java
@@ -64,10 +64,16 @@ public class MyBook {
     protected MyBook() {}
 
     @Builder
-    public MyBook(User user, Book book, MyBookStatus myBookStatus) {
+    public MyBook(User user, Book book, LocalDate startDate, LocalDate endDate, Integer page, Integer rating, MyBookStatus myBookStatus, LocalDateTime createdDate, LocalDateTime updateDate) {
         this.user = user;
         this.book = book;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.page = page;
+        this.rating = rating;
         this.myBookStatus = myBookStatus;
+        this.createdDate = LocalDateTime.now();
         this.isDeleted = false;
     }
+
 }

--- a/src/main/java/com/std/tothebook/api/service/MyBookService.java
+++ b/src/main/java/com/std/tothebook/api/service/MyBookService.java
@@ -1,14 +1,21 @@
 package com.std.tothebook.api.service;
 
+import com.std.tothebook.api.domain.dto.AddMyBookRequest;
 import com.std.tothebook.api.domain.dto.FindMyBookResponse;
 import com.std.tothebook.api.domain.dto.FindMyBooksResponse;
+import com.std.tothebook.api.entity.Book;
+import com.std.tothebook.api.entity.MyBook;
+import com.std.tothebook.api.entity.User;
+import com.std.tothebook.api.repository.BookRepository;
 import com.std.tothebook.api.repository.MyBookRepository;
+import com.std.tothebook.api.repository.UserRepository;
 import com.std.tothebook.exception.ExpectedException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,6 +25,8 @@ import java.util.Optional;
 public class MyBookService {
 
     private final MyBookRepository myBookRepository;
+    private final UserRepository userRepository;
+    private final BookRepository bookRepository;
 
     public List<FindMyBooksResponse> getMybooks(long userId){
         final var myBooks = myBookRepository.findMyBookByUserId(userId);
@@ -36,5 +45,28 @@ public class MyBookService {
         }
 
         return optionalMyBook.get();
+    }
+
+    @Transactional
+    public FindMyBookResponse addMyBook(AddMyBookRequest request){
+
+        User user = userRepository.getReferenceById(request.getUserId());
+
+        Book book = bookRepository.getReferenceById(request.getBookId());
+
+        MyBook myBook = MyBook.builder()
+                .user(user)
+                .book(book)
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .page(request.getPage())
+                .rating(request.getRating())
+                .myBookStatus(request.getMyBookStatus())
+                .build();
+
+        MyBook savedMyBook = myBookRepository.save(myBook);
+
+        return myBookRepository.findMyBookById(savedMyBook.getId())
+                .orElseThrow(() -> new ExpectedException(HttpStatus.NOT_FOUND, "저장된 MyBook을 찾을 수 없습니다."));
     }
 }


### PR DESCRIPTION
## 독서기록(내 서재) 등록 기능 추가
### 설명
1. MyBook Entity와 연관관계가 있는 Entity의 프록시 객체를 생성하여 JpaRepository의 save 메소드를 통해 독서기록을 등록하였습니다
2. 직렬화 오류가 발생하는 Book Entity의 Cateogry 필드에 @JsonIgnore를 추가하였습니다.
3. 저장 후 독서 기록 상세를 조회할 수 있도록 추후 redirect로 변경할 예정입니다. 아직 화면이 만들어지지 않아, 주석처리 하였습니다.
4. 유효성 검증은 추후 추가할 예정입니다.