### PR TITLE
Feat: 이메일 발송 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
 	implementation 'com.querydsl:querydsl-jpa'
 	implementation 'com.querydsl:querydsl-apt'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/std/tothebook/api/controller/api/CertificationController.java
+++ b/src/main/java/com/std/tothebook/api/controller/api/CertificationController.java
@@ -1,0 +1,31 @@
+package com.std.tothebook.api.controller.api;
+
+import com.std.tothebook.api.domain.dto.SendCertificationNumberRequest;
+import com.std.tothebook.api.service.CertificationService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.mail.MessagingException;
+
+@Tag(name = "인증")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/certification")
+public class CertificationController {
+
+    private final CertificationService certificationService;
+
+    @Operation(summary = "인증 번호 생성 후 메일 전송", description = "패스워드 암호화가 번거롭다 느껴서 실행 시에 application 내 정보 비워뒀음")
+    @PostMapping("/send")
+    public ResponseEntity<Void> sendNumber(@RequestBody SendCertificationNumberRequest payload) throws MessagingException {
+        certificationService.sendNumber(payload);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/std/tothebook/api/domain/dto/SendCertificationNumberRequest.java
+++ b/src/main/java/com/std/tothebook/api/domain/dto/SendCertificationNumberRequest.java
@@ -1,0 +1,30 @@
+package com.std.tothebook.api.domain.dto;
+
+import com.std.tothebook.exception.ValidateDTOException;
+import com.std.tothebook.exception.enums.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Schema(description = "인증번호 전송 Request")
+public class SendCertificationNumberRequest {
+
+    @Schema(description = "이메일")
+    private String email;
+
+    public SendCertificationNumberRequest(String email) {
+        this.email = email;
+    }
+
+    // TODO 생성자 validation 체크 추가 예정
+//    public SendCertificationNumberRequest(String email) {
+//        if (email == null || email.isEmpty()) {
+//            throw new ValidateDTOException(ErrorCode.EMAIL_VALIDATE);
+//        }
+//        this.email = email;
+//    }
+}

--- a/src/main/java/com/std/tothebook/api/service/CertificationService.java
+++ b/src/main/java/com/std/tothebook/api/service/CertificationService.java
@@ -1,0 +1,53 @@
+package com.std.tothebook.api.service;
+
+import com.std.tothebook.api.domain.dto.SendCertificationNumberRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+
+@Service
+@RequiredArgsConstructor
+public class CertificationService {
+
+    private final EmailSendService emailSendService;
+
+    public void sendNumber(SendCertificationNumberRequest payload) throws MessagingException {
+        int certificationNumber = createCertificationNumber();
+        String text = getEmailText(certificationNumber);
+
+        // TODO 인증번호 저장
+
+        emailSendService.sendMail(payload.getEmail()
+                , "[북쪽으로] 인증 번호 안내"
+                , text);
+    }
+
+    private int createCertificationNumber() {
+        // TODO 인증번호 생성
+        return 111111;
+    }
+
+    private String getEmailText(int certificationNumber) {
+        return "<div style='margin:2em;'>\n" +
+                "<h1>북쪽으로</h1>\n" +
+                "<br>\n" +
+                "<span style=\"font-family: 맑은 고딕;\">\n" +
+                "북쪽으로,\n" +
+                "<strong>\n" +
+                "<span style=\"color:darkgreen\"> 회원 가입을 위한 이메일 인증번호</span>\n" +
+                "</strong>\n" +
+                "입니다.\n" +
+                "<br>\n" +
+                "<br>\n" +
+                "안녕하세요.<br>북쪽으로 입니다.<br><br>\n" +
+                "아래의 인증 번호를 입력해주세요.<br>\n" +
+                "<div style=\"border:1px solid darkgreen; margin:1em 0 0 0; padding: 1em;\">\n" +
+                "<p>인증번호: <strong>" + certificationNumber + "</strong></p>\n" +
+                "</div>\n" +
+                "<br>\n" +
+                "감사합니다.\n" +
+                "</span>\n" +
+                "</div>";
+    }
+}

--- a/src/main/java/com/std/tothebook/api/service/EmailSendService.java
+++ b/src/main/java/com/std/tothebook/api/service/EmailSendService.java
@@ -1,0 +1,32 @@
+package com.std.tothebook.api.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Service
+@RequiredArgsConstructor
+public class EmailSendService {
+
+    private final JavaMailSender javaMailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromEmailId;
+
+    public void sendMail(String to, String subject, String text) throws MessagingException {
+        MimeMessage mailMessage = javaMailSender.createMimeMessage();
+
+        mailMessage.setFrom(fromEmailId + "@naver.com");
+        mailMessage.addRecipients(Message.RecipientType.TO, to);
+        mailMessage.setSubject(subject);
+        mailMessage.setText(text, "utf-8", "html");
+
+        javaMailSender.send(mailMessage);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,18 @@ spring:
     suffix: .html
     #cache: false 타임리프 소스 변경 시 서버를 재시작 하지 않아도 적용해줌. (배포 시 true로 변경할 것)
 
+  mail:
+    host: smtp.naver.com # 구글 계정 만들기까지 네이버 계정 사용
+    port: 587
+    username: id
+    password: password
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
 # log 설정
 logging:
   level:

--- a/src/main/resources/templates/app/signUp/form.html
+++ b/src/main/resources/templates/app/signUp/form.html
@@ -91,7 +91,7 @@
 </body>
 </html>
 <script type="text/javascript">
-    let isDuplicatedEmail = false;
+    let isDuplicatedEmail = true;
 
     const checkEmail = () => {
         const emailDiv = document.getElementById('duplicate-email-div');
@@ -107,15 +107,15 @@
                     isDuplicatedEmail = true;
                     emailDiv.classList.remove('d-none');
                 } else {
+                    isDuplicatedEmail = false;
                     emailDiv.classList.add('d-none');
+                    sendCertificateNumber();
                 }
             })
             .catch((error) => {
                 console.log(error);
                 alert('오류가 발생했습니다.');
             });
-
-        sendCertificateNumber();
     };
 
     const validateForCheckEmail = (email) => {
@@ -126,7 +126,7 @@
 
         const regex = new RegExp('[a-z0-9]+@[a-z]+\.[a-z]{2,3}');
         if (!regex.test(email)) {
-            alert("이메일 형식이 아닙니다.");
+            alert('이메일 형식이 아닙니다.');
             return false;
         }
 
@@ -134,6 +134,13 @@
     }
 
     const sendCertificateNumber = () => {
+        if (isDuplicatedEmail) {
+            alert('이메일이 중복됩니다.');
+            return;
+        }
+        console.log('이메일 인증 진행');
+    };
 
+    const signUp = () => {
     };
 </script>


### PR DESCRIPTION
이메일 발송 기능을 추가했습니다.

- 이메일 발송이 인증번호 발송 시에만 사용되고 있어 이메일 컨트롤러는 따로 만들지 않았습니다.
- 인증번호 발송 Request는 검증이 덜 됐습니다... (TODO)
- 인증번호 생성 및 저장 기능은 추가 예정입니다.
- 이메일과 비밀번호는 거짓 데이터입니다.