### PR TITLE
Fix: 인증번호 발송 전 이메일 규칙 체크 추가

### DIFF
--- a/src/main/java/com/std/tothebook/api/service/CertificationService.java
+++ b/src/main/java/com/std/tothebook/api/service/CertificationService.java
@@ -5,6 +5,7 @@ import com.std.tothebook.api.domain.dto.ValidateCertificationNumberRequest;
 import com.std.tothebook.api.entity.Certification;
 import com.std.tothebook.api.repository.CertificationRepository;
 import com.std.tothebook.exception.CertificationException;
+import com.std.tothebook.exception.ExpectedException;
 import com.std.tothebook.exception.enums.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -14,12 +15,17 @@ import javax.mail.MessagingException;
 import javax.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.util.Random;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
 public class CertificationService {
 
     private final int CERTIFICATION_NUMBER_LENGTH = 6;
+    private final String REGEX_EMAIL = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$";
+
+    private final Pattern emailPattern = Pattern.compile(REGEX_EMAIL);
 
     private final EmailSendService emailSendService;
     private final CertificationRepository certificationRepository;
@@ -32,6 +38,8 @@ public class CertificationService {
      */
     @Transactional
     public void sendNumber(SendCertificationNumberRequest payload) throws MessagingException {
+        validateForSendNumber(payload);
+
         String certificationNumber = createCertificationNumber();
 
         addCertificationNumber(payload, certificationNumber);
@@ -76,6 +84,14 @@ public class CertificationService {
                 .number(number)
                 .limitedMinutes(limitedMinutes)
                 .build());
+    }
+
+    // 인증번호 생성 전 검증
+    private void validateForSendNumber(SendCertificationNumberRequest payload) {
+        Matcher matcher = emailPattern.matcher(payload.getEmail());
+        if (!matcher.matches()) {
+            throw new ExpectedException(ErrorCode.REGULAR_EXPRESSION_EMAIL);
+        }
     }
 
     // 인증번호 생성


### PR DESCRIPTION
회원 가입 기능을 만들면서 잊고 있던 이메일 규칙 인증이 떠올랐습니다.

인증번호 발송 전에도 이메일 형식이 맞는지 체크해야 할 것 같아 검증 코드를 추가하였습니다.
사용하고 있는 정규식은 SignUpService에서도 동일하게 사용하고 있습니다.
해당 코드가 중복되고 관리 포인트가 2개 이상이 되고 있기 때문에 추후 yaml 파일을 분리하여 관리할 수 있도록 수정하겠습니다.