### PR TITLE
Refactor: 이메일 규칙 검증 방식 수정 (회원 가입, 인증 번호 전송)

### DIFF
--- a/src/main/java/com/std/tothebook/service/CertificationService.java
+++ b/src/main/java/com/std/tothebook/service/CertificationService.java
@@ -7,6 +7,7 @@ import com.std.tothebook.repository.CertificationRepository;
 import com.std.tothebook.exception.CertificationException;
 import com.std.tothebook.exception.ExpectedException;
 import com.std.tothebook.exception.enums.ErrorCode;
+import com.std.tothebook.util.UserInputValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -23,9 +24,6 @@ import java.util.regex.Pattern;
 public class CertificationService {
 
     private final int CERTIFICATION_NUMBER_LENGTH = 6;
-    private final String REGEX_EMAIL = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$";
-
-    private final Pattern emailPattern = Pattern.compile(REGEX_EMAIL);
 
     private final EmailSendService emailSendService;
     private final CertificationRepository certificationRepository;
@@ -38,7 +36,7 @@ public class CertificationService {
      */
     @Transactional
     public void sendNumber(SendCertificationNumberRequest payload) throws MessagingException {
-        validateForSendNumber(payload);
+        UserInputValidator.validateEmail(payload.getEmail());
 
         String certificationNumber = createCertificationNumber();
 
@@ -84,14 +82,6 @@ public class CertificationService {
                 .number(number)
                 .limitedMinutes(limitedMinutes)
                 .build());
-    }
-
-    // 인증번호 생성 전 검증
-    private void validateForSendNumber(SendCertificationNumberRequest payload) {
-        Matcher matcher = emailPattern.matcher(payload.getEmail());
-        if (!matcher.matches()) {
-            throw new ExpectedException(ErrorCode.REGULAR_EXPRESSION_EMAIL);
-        }
     }
 
     // 인증번호 생성

--- a/src/main/java/com/std/tothebook/service/SignUpService.java
+++ b/src/main/java/com/std/tothebook/service/SignUpService.java
@@ -5,6 +5,7 @@ import com.std.tothebook.entity.User;
 import com.std.tothebook.repository.UserRepository;
 import com.std.tothebook.exception.ExpectedException;
 import com.std.tothebook.exception.enums.ErrorCode;
+import com.std.tothebook.util.UserInputValidator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,10 +18,7 @@ import java.util.regex.Pattern;
 public class SignUpService {
 
     private final String REGEX_PASSWORD = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{10,}$";
-    private final String REGEX_EMAIL = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*@[0-9a-zA-Z]([-_.]?[0-9a-zA-Z])*.[a-zA-Z]{2,3}$";
-
     private final Pattern passwordPattern = Pattern.compile(REGEX_PASSWORD);
-    private final Pattern emailPattern = Pattern.compile(REGEX_EMAIL);
 
     private final UserService userService;
 
@@ -47,20 +45,18 @@ public class SignUpService {
 
     // 회원 가입 검증
     private void validateForSignUp(SignUpRequest payload) {
+        // 이메일 규칙 체크
+        UserInputValidator.validateEmail(payload.getEmail());
+        // 비밀번호 규칙 체크
+        Matcher matcher = passwordPattern.matcher(payload.getPassword());
+        if (!matcher.matches()) {
+            throw new ExpectedException(ErrorCode.REGULAR_EXPRESSION_PASSWORD);
+        }
+
         // 이메일, 닉네임 중복 체크
         if (userService.isEmailDuplicated(payload.getEmail())
                 || userService.isNicknameDuplicated(payload.getNickname())) {
             throw new ExpectedException(ErrorCode.DUPLICATE_USER);
-        }
-        // 이메일 규칙 체크
-        Matcher matcher = emailPattern.matcher(payload.getEmail());
-        if (!matcher.matches()) {
-            throw new ExpectedException(ErrorCode.REGULAR_EXPRESSION_EMAIL);
-        }
-        // 비밀번호 규칙 체크
-        matcher = passwordPattern.matcher(payload.getPassword());
-        if (!matcher.matches()) {
-            throw new ExpectedException(ErrorCode.REGULAR_EXPRESSION_PASSWORD);
         }
     }
 }


### PR DESCRIPTION
지난번에 수정했던 이메일 규칙 검증 코드를
기존에 존재하던 '회원 가입' 기능과 '인증 번호 전송' 기능에 코드를 교체했습니다.

'이메일 규칙 검증 기능'이 제대로 동작하는지는 지난 작업에 테스트 코드를 통해 확인하였습니다.
다만 코드를 교체하고서 '회원 가입' 기능과 '인증 번호 전송' 기능이 제대로 동작하는지 테스트 해보지 않았습니다.

테스트 해보지 않은 이유는 아래와 같습니다.
1) 회원 가입 기능, 인증 번호 전송 기능은 이미 제대로 동작한다는 전제 하에 추가가 된 기능입니다.
2) 이메일 규칙 검증 기능은 저번에 테스트 코드를 통해 동작 확인되었습니다.
3) 이메일 규칙 검증 기능 부분만 교체되었기 때문에 문제가 발생하지 않을 것이라고 판단하였습니다.

만약 회원 가입 기능과 인증 번호 전송 기능이 제대로 동작하는지 확인하려면
2개 기능에 대한 TDD 코드가 추가되어야 할 듯 합니다.
다만, TDD를 추가할 때 '이메일 규칙 검증 기능'은 static으로 되어있어 해당 기능 자체가 mocking 될 것으로 보입니다.
그럼 TDD를 추가하는 의미가 없어집니다... 이 부분에 대해서는 추후 논의해보고 싶습니다.