### PR TITLE
Feat: 커스텀 어노테이션 기반 로그인 유저 정보 가져오기 기능 추가

### DIFF
--- a/src/main/java/com/std/tothebook/annotation/User.java
+++ b/src/main/java/com/std/tothebook/annotation/User.java
@@ -1,0 +1,13 @@
+package com.std.tothebook.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+
+@Target({PARAMETER, FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface User {
+}

--- a/src/main/java/com/std/tothebook/common/WebConfig.java
+++ b/src/main/java/com/std/tothebook/common/WebConfig.java
@@ -1,0 +1,17 @@
+package com.std.tothebook.common;
+
+import com.std.tothebook.common.resolvers.LoginUserArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(new LoginUserArgumentResolver());
+    }
+}

--- a/src/main/java/com/std/tothebook/common/resolvers/LoginUserArgumentResolver.java
+++ b/src/main/java/com/std/tothebook/common/resolvers/LoginUserArgumentResolver.java
@@ -1,0 +1,34 @@
+package com.std.tothebook.common.resolvers;
+
+import com.std.tothebook.annotation.User;
+import com.std.tothebook.exception.JwtAuthenticationException;
+import com.std.tothebook.exception.enums.ErrorCode;
+import com.std.tothebook.security.LoginUser;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasUserAnnotation = parameter.hasParameterAnnotation(User.class);
+        boolean hasLoginUserType = LoginUser.class.isAssignableFrom(parameter.getParameterType());
+
+        return hasUserAnnotation && hasLoginUserType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication instanceof AnonymousAuthenticationToken) {
+            throw JwtAuthenticationException.create(ErrorCode.CERTIFICATION_NOT_VALIDATED_USER.getMessage());
+        }
+        return authentication.getPrincipal();
+    }
+}

--- a/src/main/java/com/std/tothebook/config/JwtTokenProvider.java
+++ b/src/main/java/com/std/tothebook/config/JwtTokenProvider.java
@@ -4,7 +4,7 @@ import com.std.tothebook.enums.AuthorizationType;
 import com.std.tothebook.service.JwtTokenService;
 import com.std.tothebook.exception.JwtAuthenticationException;
 import com.std.tothebook.security.JsonWebToken;
-import com.std.tothebook.security.SecurityUser;
+import com.std.tothebook.security.LoginUser;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
@@ -113,12 +113,12 @@ public class JwtTokenProvider {
     }
 
     // 인증된 회원 정보 조회
-    public SecurityUser getUser() {
+    public LoginUser getUser() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
         if (authentication instanceof AnonymousAuthenticationToken) {
             throw JwtAuthenticationException.create("인증 되지 않은 사용자입니다.");
         }
-        return (SecurityUser) authentication.getPrincipal();
+        return (LoginUser) authentication.getPrincipal();
     }
 
     // 인증된 회원 id 조회

--- a/src/main/java/com/std/tothebook/controller/api/MyBookController.java
+++ b/src/main/java/com/std/tothebook/controller/api/MyBookController.java
@@ -17,7 +17,6 @@ import javax.validation.Valid;
 @RequestMapping("/api/my-book")
 @RestController
 @RequiredArgsConstructor
-//TODO : ArgumentResolver로 로그인한 대상의 객체 가져오도록 변경
 public class MyBookController {
 
     private final MyBookService myBookService;

--- a/src/main/java/com/std/tothebook/dto/LoginUserResponse.java
+++ b/src/main/java/com/std/tothebook/dto/LoginUserResponse.java
@@ -1,6 +1,6 @@
 package com.std.tothebook.dto;
 
-import com.std.tothebook.security.SecurityUser;
+import com.std.tothebook.security.LoginUser;
 import lombok.Getter;
 
 /**
@@ -13,7 +13,7 @@ public class LoginUserResponse {
     private final String email;
     private final String nickname;
 
-    public LoginUserResponse(SecurityUser user) {
+    public LoginUserResponse(LoginUser user) {
         this.id = user.getId();
         this.email = user.getUsername();
         this.nickname = user.getNickname();

--- a/src/main/java/com/std/tothebook/exception/enums/ErrorCode.java
+++ b/src/main/java/com/std/tothebook/exception/enums/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     CERTIFICATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "인증번호를 다시 발급해주세요."),
     CERTIFICATION_PASSED_LIMITED_TIME(HttpStatus.BAD_REQUEST, "인증 시간이 만료되었습니다."),
     CERTIFICATION_ALREADY(HttpStatus.BAD_REQUEST, "인증번호를 다시 발급해주세요."),
+    CERTIFICATION_NOT_VALIDATED_USER(HttpStatus.UNAUTHORIZED, "인증 되지 않은 사용자입니다."),
 
     /**
      * 카테고리

--- a/src/main/java/com/std/tothebook/security/CustomUserDetailsService.java
+++ b/src/main/java/com/std/tothebook/security/CustomUserDetailsService.java
@@ -19,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         User user = userRepository.findById(Long.valueOf(id))
                 .orElseThrow(() -> new UsernameNotFoundException("회원을 찾을 수 없습니다."));
 
-        return SecurityUser.builder()
+        return LoginUser.builder()
                 .id(user.getId())
                 .email(user.getEmail())
                 .password(user.getPassword())

--- a/src/main/java/com/std/tothebook/security/LoginUser.java
+++ b/src/main/java/com/std/tothebook/security/LoginUser.java
@@ -11,7 +11,7 @@ import java.util.Collection;
  * UserDetails 구현 클래스
  * Jwt -> 회원 정보 조회하는 dto
  */
-public class SecurityUser implements UserDetails {
+public class LoginUser implements UserDetails {
 
     private final long id;
     private final String email;
@@ -21,7 +21,7 @@ public class SecurityUser implements UserDetails {
     private final String nickname;
 
     @Builder
-    public SecurityUser(long id, String email, String password, String nickname) {
+    public LoginUser(long id, String email, String password, String nickname) {
         this.id = id;
         this.email = email;
         this.password = password;

--- a/src/main/java/com/std/tothebook/service/SignInService.java
+++ b/src/main/java/com/std/tothebook/service/SignInService.java
@@ -7,7 +7,7 @@ import com.std.tothebook.repository.UserRepository;
 import com.std.tothebook.config.JwtTokenProvider;
 import com.std.tothebook.exception.ExpectedException;
 import com.std.tothebook.exception.enums.ErrorCode;
-import com.std.tothebook.security.SecurityUser;
+import com.std.tothebook.security.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -43,7 +43,7 @@ public class SignInService {
     }
 
     public void signOut() {
-        SecurityUser user = jwtTokenProvider.getUser();
+        LoginUser user = jwtTokenProvider.getUser();
 
         jwtTokenService.expireRefreshToken(user.getId());
     }

--- a/src/main/java/com/std/tothebook/service/UserService.java
+++ b/src/main/java/com/std/tothebook/service/UserService.java
@@ -8,7 +8,7 @@ import com.std.tothebook.repository.UserRepository;
 import com.std.tothebook.exception.ExpectedException;
 import com.std.tothebook.exception.UserException;
 import com.std.tothebook.exception.enums.ErrorCode;
-import com.std.tothebook.security.SecurityUser;
+import com.std.tothebook.security.LoginUser;
 import com.std.tothebook.util.UserInputValidator;
 import com.std.tothebook.vo.Mail;
 import lombok.RequiredArgsConstructor;
@@ -257,7 +257,7 @@ public class UserService {
 
     @Transactional
     public void withdraw() {
-        SecurityUser loginUser = jwtTokenProvider.getUser();
+        LoginUser loginUser = jwtTokenProvider.getUser();
 
         jwtTokenService.expireRefreshToken(loginUser.getId());
 

--- a/src/test/java/com/std/tothebook/common/resolvers/LoginUserArgumentResolverTest.java
+++ b/src/test/java/com/std/tothebook/common/resolvers/LoginUserArgumentResolverTest.java
@@ -1,0 +1,106 @@
+package com.std.tothebook.common.resolvers;
+
+import com.std.tothebook.annotation.User;
+import com.std.tothebook.security.LoginUser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class LoginUserArgumentResolverTest {
+
+    private LoginUserArgumentResolver resolver;
+
+    @BeforeEach
+    public void setUp() {
+        resolver = new LoginUserArgumentResolver();
+    }
+
+    public void testMethod(@User LoginUser user) {}
+
+    public void testMethod2(@User com.std.tothebook.entity.User user) {}
+
+    public void testMethod3(LoginUser user) {}
+
+    @DisplayName("supportsParameter 검증 (mock)")
+    @Test
+    void supportsParameter_mock() {
+        MethodParameter mockParameter = mock(MethodParameter.class);
+
+        when(mockParameter.hasParameterAnnotation(User.class))
+                .thenReturn(true);
+        doReturn(LoginUser.class)
+                .when(mockParameter)
+                .getParameterType();
+
+        boolean isSupports = resolver.supportsParameter(mockParameter);
+        assertThat(isSupports).isTrue();
+    }
+
+    @DisplayName("supportsParameter 검증 (생성자)")
+    @Test
+    void supportsParameter_constructor() throws NoSuchMethodException {
+        MethodParameter methodParameter =
+                new MethodParameter(getClass().getMethod("testMethod", LoginUser.class), 0);
+
+        boolean isSupports = resolver.supportsParameter(methodParameter);
+        assertThat(isSupports).isTrue();
+    }
+
+    @DisplayName("supportsParameter 검증 - 지원 X (클래스 오류)")
+    @Test
+    void supportsParameter_notSupport_class() throws NoSuchMethodException {
+        MethodParameter methodParameter =
+                new MethodParameter(getClass().getMethod("testMethod2", com.std.tothebook.entity.User.class), 0);
+
+        boolean isSupports = resolver.supportsParameter(methodParameter);
+        assertThat(isSupports).isFalse();
+    }
+
+    @DisplayName("supportsParameter 검증 - 지원 X (어노테이션)")
+    @Test
+    void supportsParameter_notSupport_annotation() throws NoSuchMethodException {
+        MethodParameter methodParameter =
+                new MethodParameter(getClass().getMethod("testMethod3", LoginUser.class), 0);
+
+        boolean isSupports = resolver.supportsParameter(methodParameter);
+        assertThat(isSupports).isFalse();
+    }
+
+    @Test
+    void resolveArgument() throws Exception {
+        // given
+        LoginUser loginUser = LoginUser.builder()
+                .id(0L)
+                .email("tester@abc.com")
+                .password("1234")
+                .nickname("nickname")
+                .build();
+
+        SecurityContext mockSecurityContext = mock(SecurityContext.class);
+        Authentication mockAuthentication = mock(Authentication.class);
+
+        when(mockAuthentication.getPrincipal())
+                .thenReturn(loginUser);
+        when(mockSecurityContext.getAuthentication())
+                .thenReturn(mockAuthentication);
+        SecurityContextHolder.setContext(mockSecurityContext);
+
+        // when
+        Object result = resolver.resolveArgument(null, null, null, null);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result).isInstanceOf(LoginUser.class);
+
+        LoginUser resultUser = (LoginUser) result;
+        assertThat(resultUser).isEqualTo(loginUser);
+    }
+
+}


### PR DESCRIPTION
안녕하세요? 오랜만이에용..
요청하신 대로 로그인 한 유저가 커스텀 어노테이션을 파라미터로 가져올 경우 ArgumentResolver에서 가져올 수 있도록 수정해봤습니다!
내용 확인해주시면 기존 코드에도 대체할 수 있도록 수정하겠습니다~

- 커스텀 어노테이션: @ User
- 가져오는 로그인 객체: LoginUser

그리고 테스트 코드도 추가해봤어요!
기특하다 나..
(변경된 파일이 많아도 객체명을 SecurityUser -> LoginUser로 변경하면서 나온 것들입니다)